### PR TITLE
#45: Fix reflow adds unnecessary space after xml tag

### DIFF
--- a/CommentsVS.Test/CommentReflowEngineTests.cs
+++ b/CommentsVS.Test/CommentReflowEngineTests.cs
@@ -90,6 +90,17 @@ public sealed class CommentReflowEngineTests
         Assert.IsTrue(result.Any(l => l.Contains("ThisIsAVeryLongWordThatExceedsMaxWidth")));
     }
 
+    [TestMethod]
+    public void WrapText_WithXmlTags_NoSpaceBeforePunctuation()
+    {
+        var text = "This is a test with an inline tag <see cref=\"MyClass\"/>.";
+        List<string> result = TestWrapText(text, maxWidth: 30);
+
+        var joined = string.Join(" ", result);
+        // The punctuation should not be separated from the tag
+        Assert.Contains("<see cref=\"MyClass\"/>.", joined, "Punctuation should be right after XML tag");
+    }
+
     #endregion
 
     #region Whitespace Normalization Tests
@@ -386,7 +397,11 @@ public sealed class CommentReflowEngineTests
             }
             else if (currentLength + 1 + tokenLength <= maxWidth)
             {
-                currentLine.Append(' ');
+                if (!(tokenLength == 1 && char.IsPunctuation(token.Single())))
+                {
+                    currentLine.Append(' ');
+                }
+
                 currentLine.Append(token);
                 currentLength += 1 + tokenLength;
             }

--- a/src/Services/CommentReflowEngine.cs
+++ b/src/Services/CommentReflowEngine.cs
@@ -292,7 +292,11 @@ namespace CommentsVS.Services
                 }
                 else if (currentLength + 1 + tokenLength <= maxWidth)
                 {
-                    currentLine.Append(' ');
+                    if (!(tokenLength == 1 && char.IsPunctuation(token.Single())))
+                    {
+                        currentLine.Append(' ');
+                    }
+
                     currentLine.Append(token);
                     currentLength += 1 + tokenLength;
                 }


### PR DESCRIPTION
This PR fixes the issue #45 where reflow adds a space between XML tags and punctuation (or `,`, `;`, ...).

I added a test for this behavior as well.